### PR TITLE
feat: add 2 tests based on good/bad plot from upstream issue

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -249,6 +249,7 @@ class TestLogLocator:
         assert_array_equal(ll.tick_values(1, 1e7), test_value)
 
     def test_tick_values_not_empty(self):
+        mpl.rcParams['_internal.classic_mode'] = False
         ll = mticker.LogLocator(subs=(1, 2, 5))
         test_value = np.array([1.e-01, 2.e-01, 5.e-01, 1.e+00, 2.e+00, 5.e+00,
                                1.e+01, 2.e+01, 5.e+01, 1.e+02, 2.e+02, 5.e+02,

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -239,6 +239,25 @@ class TestLogLocator:
         assert loc._base == 4
         assert list(loc._subs) == [2.0]
 
+    def test_tick_values_correct(self):
+        ll = mticker.LogLocator(subs=(1, 2, 5))
+        test_value = np.array([1.e-01, 2.e-01, 5.e-01, 1.e+00, 2.e+00, 5.e+00,
+                               1.e+01, 2.e+01, 5.e+01, 1.e+02, 2.e+02, 5.e+02,
+                               1.e+03, 2.e+03, 5.e+03, 1.e+04, 2.e+04, 5.e+04,
+                               1.e+05, 2.e+05, 5.e+05, 1.e+06, 2.e+06, 5.e+06,
+                               1.e+07, 2.e+07, 5.e+07, 1.e+08, 2.e+08, 5.e+08])
+        assert_array_equal(ll.tick_values(1, 1e7), test_value)
+
+    def test_tick_values_not_empty(self):
+        ll = mticker.LogLocator(subs=(1, 2, 5))
+        test_value = np.array([1.e-01, 2.e-01, 5.e-01, 1.e+00, 2.e+00, 5.e+00,
+                               1.e+01, 2.e+01, 5.e+01, 1.e+02, 2.e+02, 5.e+02,
+                               1.e+03, 2.e+03, 5.e+03, 1.e+04, 2.e+04, 5.e+04,
+                               1.e+05, 2.e+05, 5.e+05, 1.e+06, 2.e+06, 5.e+06,
+                               1.e+07, 2.e+07, 5.e+07, 1.e+08, 2.e+08, 5.e+08,
+                               1.e+09, 2.e+09, 5.e+09])
+        assert_array_equal(ll.tick_values(1, 1e8), test_value)
+
 
 class TestNullLocator:
     def test_set_params(self):


### PR DESCRIPTION
The test cases are based on the demonstration of the issue in upstream issue #24092

The test case for bad plot (test_tick_values_not_empty) should fail until we implement our fix.

The test case for good plot (test_tick_values_correct) should already succeed and continue to succeed after we implement our fix.