### PR TITLE
fix: revert simplification of stride calculation in LogLocator

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2386,7 +2386,8 @@ class LogLocator(Locator):
         # Get decades between major ticks.
         stride = (max(math.ceil(numdec / (numticks - 1)), 1)
                   if mpl.rcParams['_internal.classic_mode'] else
-                  (numdec + 1) // numticks + 1)
+                  next(s for s in itertools.count(1)
+                       if numdec // s + 1 <= numticks))
 
         # if we have decided that the stride is as big or bigger than
         # the range, clip the stride back to the available range - 1

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2383,12 +2383,6 @@ class LogLocator(Locator):
         else:
             subs = self._subs
 
-        def alt_stride():
-            s = 1
-            while numdec // s + 1 > numticks:
-                s += 1
-            return s
-
         # Get decades between major ticks.
         stride = (max(math.ceil(numdec / (numticks - 1)), 1)
                   if mpl.rcParams['_internal.classic_mode'] else

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2383,10 +2383,17 @@ class LogLocator(Locator):
         else:
             subs = self._subs
 
+        def alt_stride():
+            s = 1
+            while numdec // s + 1 > numticks:
+                s += 1
+            return s
+
         # Get decades between major ticks.
         stride = (max(math.ceil(numdec / (numticks - 1)), 1)
                   if mpl.rcParams['_internal.classic_mode'] else
-                  (numdec + 1) // numticks + 1)
+                  alt_stride())
+                  # (numdec + 1) // numticks + 1)
 
         # if we have decided that the stride is as big or bigger than
         # the range, clip the stride back to the available range - 1


### PR DESCRIPTION
Reverting the stride calculation to what it was before [this commit](https://github.com/matplotlib/matplotlib/commit/a06f343dee3cebf035b74f65ea00b8842af448e9)
now passes the new tests.