### PR TITLE
mnt: simplify stride calculation in LogLocator.tick_values

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2386,8 +2386,7 @@ class LogLocator(Locator):
         # Get decades between major ticks.
         stride = (max(math.ceil(numdec / (numticks - 1)), 1)
                   if mpl.rcParams['_internal.classic_mode'] else
-                  next(s for s in itertools.count(1)
-                       if numdec // s + 1 <= numticks))
+                  numdec // numticks + 1)
 
         # if we have decided that the stride is as big or bigger than
         # the range, clip the stride back to the available range - 1


### PR DESCRIPTION
simplifies the stride calculation again, but correctly this time.
